### PR TITLE
Post comment on PR build

### DIFF
--- a/step.yml
+++ b/step.yml
@@ -16,7 +16,16 @@ host_os_tags:
 deps:
   apt_get:
   - name: php7.0
-run_if: .IsCI | and (not .IsPR)
+run_if: |-
+  {{if .IsCI}}
+    {{if .IsPR}}
+      {{enveq "POST_JIRA_COMMENT_ON_PR" "true"}}
+    {{else}}
+      true
+    {{end}}
+  {{else}}
+    false
+  {{end}}
 inputs:
   - git_branch: $BITRISE_GIT_BRANCH
     opts:


### PR DESCRIPTION
Added possibility to enable posting comments for builds which was triggered by PR. All you need to do is to define _POST_JIRA_COMMENT_ON_PR_ environment variable and set its value to _true_. If this env var doesn't exist comment will be not posted on build triggered by PR.
