### PR TITLE
Add optional `jira_issue_key` so previous steps can determine key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .bitrise.secrets.yml
+.idea/
+*.iml

--- a/application.php
+++ b/application.php
@@ -17,6 +17,7 @@ $input = new ArgvInput(
         isset($_SERVER['jira_build_message']) ? $_SERVER['jira_build_message'] : null,
         isset($_SERVER['jira_url']) ? $_SERVER['jira_url'] : null,
         isset($_SERVER['jira_project']) ? $_SERVER['jira_project'] : null,
+        isset($_SERVER['jira_issue_key']) ? $_SERVER['jira_issue_key'] : null,
     ]
 );
 

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -9,6 +9,7 @@ app:
   - JIRA_PASSWORD: $JIRA_PASSWORD
   - JIRA_URL: $JIRA_URL
   - JIRA_PROJECT: $JIRA_PROJECT
+  - JIRA_ISSUE_KEY: $JIRA_ISSUE_KEY
 
 workflows:
   test_full:
@@ -25,6 +26,7 @@ workflows:
         - jira_password: $JIRA_PASSWORD
         - jira_url: $JIRA_URL
         - jira_project: $JIRA_PROJECT
+        - jira_issue_key: $JIRA_ISSUE_KEY
         - jira_build_message: |-
             Hello There
             What's up ?

--- a/step.yml
+++ b/step.yml
@@ -50,6 +50,14 @@ inputs:
       is_expand: true
       is_required: false
       value_options: []
+  - jira_issue_key:
+    opts:
+      title: "JIRA issue key"
+      summary: "JIRA issue key, if found earlier in the workflow"
+      description: "This step can find the issue key from the branch name, but if you want to provide it as part of the environment or determine it earlier in the workflow, you can."
+      is_expand: true
+      is_required: false
+      value_options: []
   - jira_build_message: |
       *$BITRISE_APP_TITLE* build *$BITRISE_BUILD_NUMBER* is now available: [Download|$BITRISE_PUBLIC_INSTALL_PAGE_URL]\n
 


### PR DESCRIPTION
To make this step more flexible, I'd like to add this new optional input.

Use-cases:
- I have another step earlier in the workflow which determines the issue key, perhaps by looking at the full commit message rather than the branch
- I want to pass the issue key as part of my trigger